### PR TITLE
Guard against destroyed scanner entities

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -160,7 +160,7 @@ const OnEntityRemoved = (
     event: OnPrePlayerMinedItemEvent | OnRobotPreMinedEvent | OnEntityDiedEvent
 ) => {
     const entity = event.entity;
-    if (entity.name == ScannerName) {
+    if (entity && entity.valid && entity.name == ScannerName) {
         RemoveSensor(entity.unit_number!);
     }
 };
@@ -234,8 +234,21 @@ const UpdateArea = () => {
             for (let j = storage.ghostScanners.length - 1; j >= 0; --j) {
                 const ghostScanner = storage.ghostScanners[j];
                 if (id == ghostScanner.id) {
+                    if (!ghostScanner.entity || !ghostScanner.entity.valid) {
+                        ModLog(`Error: Scanner ${id} entity no longer valid, dropping`);
+                        storage.ghostScanners.splice(j, 1);
+                        CleanUp(id);
+                        break;
+                    }
+
                     const controlBehavior =
                         ghostScanner.entity.get_control_behavior() as LuaConstantCombinatorControlBehavior;
+                    if (!controlBehavior) {
+                        ModLog(`Error: Scanner ${id} has no control behavior, dropping`);
+                        storage.ghostScanners.splice(j, 1);
+                        CleanUp(id);
+                        break;
+                    }
 
                     ClearCombinator(controlBehavior);
                     const signalsForCombinator = storage.scanSignals.get(id);
@@ -555,8 +568,25 @@ const GetGhostsAsSignals = (
 };
 
 const UpdateSensor = (ghostScanner: GhostScanner) => {
+    // A scanner can be destroyed without any of the removal events we listen
+    // for firing (a deleted surface, for example), which leaves a stale record
+    // in storage.ghostScanners. Dereferencing it raises "LuaEntity API call
+    // when LuaEntity was invalid", which is not recoverable, so drop it.
+    if (!ghostScanner) {
+        return;
+    }
+    if (!ghostScanner.entity || !ghostScanner.entity.valid) {
+        ModLog("Skipping ghost scanner with an invalid entity");
+        RemoveSensor(ghostScanner.id);
+        return;
+    }
+
     const controlBehavior =
         ghostScanner.entity.get_control_behavior() as LuaConstantCombinatorControlBehavior;
+    if (!controlBehavior) {
+        ModLog("Skipping ghost scanner without a control behavior");
+        return;
+    }
     if (!controlBehavior.enabled) {
         ModLog("Combinator disabled, not updating");
         ClearCombinator(controlBehavior);


### PR DESCRIPTION
A ghost scanner combinator can be removed without any of the events the mod listens for (`on_pre_player_mined_item`, `on_robot_pre_mined`, `on_entity_died`) firing — deleting the surface it sits on is one way. The record then stays in `storage.ghostScanners` with a dead `LuaEntity`, and the next `on_tick` dereferences it:

```
The mod Ghost Scanner 4 (4.0.6) caused a non-recoverable error.
Please report this error to the mod author.
Error while running event GhostScanner4::on_tick (ID 0)
LuaEntity API call when LuaEntity was invalid.
stack traceback:
        [C]: in function '__index'
        __GhostScanner4__/control.lua:195: in function 'UpdateArea'
        __GhostScanner4__/control.lua:455: in function <__GhostScanner4__/control.lua:442>
```

This is especially rough on a headless server: the process exits 255, and if the unit boots from a fixed save file rather than the latest autosave, the restart silently rewinds the world to the last graceful save. On our server it fired three times in five weeks (2026-06-21, 07-05, 07-25); the last one cost about 3h20m of play.

## The fix

Guard both places that reach through `.entity` and drop the stale record instead of dereferencing it:

- `UpdateArea` — the site in the traceback. Splices the dead record out of `storage.ghostScanners` and runs the existing `CleanUp(id)`, which is what the neighbouring "did not find scanner with ID" branch already does.
- `UpdateSensor` — same hazard, reached from `on_tick` one scanner per tick. Unregisters via the existing `RemoveSensor`.
- `OnEntityRemoved` — checks `.valid` before reading `.name` off the event entity.

Also treats a `nil` control behavior as "drop it" rather than assuming the cast holds.

## Verification

I stubbed enough of the runtime to load `control.lua` outside Factorio, poisoned `storage.ghostScanners` with an entity whose `__index` throws the same way the real API does, and drove `on_tick`:

| case | before | after |
| --- | --- | --- |
| destroyed entity, `UpdateArea` path | `control.lua:195` LuaEntity API call when LuaEntity was invalid | survives, stale record dropped |
| destroyed entity, `UpdateSensor` path | `control.lua:394` same error | survives, stale record dropped |
| healthy entity, `UpdateArea` path | ok | ok, scanner retained |
| healthy entity, `UpdateSensor` path | ok | ok, scanner retained |

`yarn build` produces no new TSTL warnings (baseline and branch are both 0) and `yarn lint` is clean.

Happy to add a changelog entry if you would like one — I left `public/changelog.txt` alone since the version number is your call.